### PR TITLE
Switch config to environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
 notebook_data/
-config/config.json
-!config/config.json.sample

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@
 至少要勾選MS Graph的`User.Read`和`Notes.Read`，才可以登陸拿token然後讀取Onenote筆記本資料
 
 
-## Config檔設定
-1. 把`config.json.sample`複製或改名為`config.json`
-2. 到剛剛在MS Azure App Registration註冊的APP總攬(overview)頁面找Application (client) ID，然後把找到的ID複製到`config.json`中對應`clientId`的value
-> 實測只需要`clientId`，使用`tenantId`的登入方式會有一些問題這裡不使用
+## 環境變數設定
+在執行範例程式前，請設定下列環境變數：
+
+* `ONENOTE_CLIENT_ID`：Azure App Registration 取得的 Application (client) ID
+* `ONENOTE_NOTEBOOK_ID`：欲讀取的筆記本 ID
+* `ONENOTE_TENANT_ID`：Tenant ID，選填，預設使用 common
 
 ## Usage
 1. 執行`node ./src/tests/listNotebooks.js`列出筆記本
-2. 找出欲讀取筆記本的ID貼至`config.json`中對應`notebookId`的value
+2. 找出欲讀取筆記本的ID後，設定至`ONENOTE_NOTEBOOK_ID`環境變數
 3. 執行`node ./src/tests/fetchNotebook.js`讀取筆記本內容，並將對應的章節內容儲存至`./notebook_data/`中
 
 ## 主要差異摘要

--- a/src/clients/onenoteClient.js
+++ b/src/clients/onenoteClient.js
@@ -3,11 +3,18 @@ const { Client } = require('@microsoft/microsoft-graph-client');
 require('isomorphic-fetch');
 
 class OneNoteClient {
-    constructor(config) {
-        this.config = config;
+    constructor(config = {}) {
+        this.config = {
+            notebookId: config.notebookId || process.env.ONENOTE_NOTEBOOK_ID,
+            clientId: config.clientId || process.env.ONENOTE_CLIENT_ID,
+            tenantId: config.tenantId || process.env.ONENOTE_TENANT_ID,
+        };
+        if (!this.config.clientId) {
+            throw new Error('ONENOTE_CLIENT_ID environment variable is required');
+        }
         this.pca = new PublicClientApplication({
             auth: {
-                clientId: config.clientId,
+                clientId: this.config.clientId,
                 authority: `https://login.microsoftonline.com/common`,
             },
             system: {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,11 @@
+const required = ['ONENOTE_CLIENT_ID'];
+for (const k of required) {
+  if (!process.env[k]) {
+    throw new Error(`Environment variable ${k} is required`);
+  }
+}
+module.exports = {
+  notebookId: process.env.ONENOTE_NOTEBOOK_ID,
+  clientId: process.env.ONENOTE_CLIENT_ID,
+  tenantId: process.env.ONENOTE_TENANT_ID,
+};

--- a/src/tests/fetchNotebook.js
+++ b/src/tests/fetchNotebook.js
@@ -1,5 +1,5 @@
 const OneNoteClient = require('../clients/onenoteClient');
-const config = require('../../config/config.json');
+const config = require('../config');
 const fs = require('fs/promises');
 const path = require('path');
 

--- a/src/tests/listNotebooks.js
+++ b/src/tests/listNotebooks.js
@@ -1,5 +1,5 @@
 const OneNoteClient = require('../clients/onenoteClient');
-const config = require('../../config/config.json');
+const config = require('../config');
 
 async function main() {
     const client = new OneNoteClient(config);


### PR DESCRIPTION
## Summary
- remove obsolete config entries in `.gitignore`
- add `src/config.js` to read settings from environment variables
- allow `OneNoteClient` to pull defaults from env vars
- update test scripts to use new config loader
- document new environment variable workflow in `README`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684ae4d82c688333813d93ee1e4cddc8