### PR TITLE
Add --min option for fetch interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## Usage
 1. 執行`node ./src/tests/listNotebooks.js`列出筆記本
 2. 找出欲讀取筆記本的ID後，設定至`ONENOTE_NOTEBOOK_ID`環境變數
-3. 執行`node ./src/tests/fetchNotebook.js`讀取筆記本內容，並將對應的章節內容儲存至`./notebook_data/`中
+3. 執行`node ./src/tests/fetchNotebook.js [--min N]`讀取筆記本內容，並將對應的章節內容儲存至`./notebook_data/`中 (N 為間隔分鐘，0 表示僅執行一次，預設 5 分鐘)
 
 ## 主要差異摘要
 


### PR DESCRIPTION
## Summary
- add command line parsing in `fetchNotebook.js` to allow `--min` interval selection
- default to 5 minutes; `0` fetches once
- document new parameter in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684aeaa4f958833386399b398d94f0d1