### PR TITLE
Fix output directories

### DIFF
--- a/src/tests/fetchNotebook.js
+++ b/src/tests/fetchNotebook.js
@@ -21,13 +21,13 @@ async function fetchAndSaveData(client) {
         console.log(`\n[${getTimestamp()}] Fetching data...`);
 
         // Create output directory if it doesn't exist
-        const outputDir = path.join(__dirname, '../notebook_data');
+        const outputDir = path.join(__dirname, '../../notebook_data');
         await fs.mkdir(outputDir, { recursive: true });
 
-        const assetsDir = path.join(__dirname, '../assets/images', client.config.notebookId);
+        const assetsDir = path.join(__dirname, '../../assets/images', client.config.notebookId);
         await fs.mkdir(assetsDir, { recursive: true });
 
-        const imgHashPath = path.join(__dirname, '../notebook_data/imgHash.json');
+        const imgHashPath = path.join(__dirname, '../../notebook_data/imgHash.json');
         let imgHash = [];
         try {
             const d = await fs.readFile(imgHashPath, 'utf8');


### PR DESCRIPTION
## Summary
- save assets and notebook data to directories at repository root

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_b_684afcb523b0833396b9fd647ac7682f