### PR TITLE
Serve notebook viewer at root

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 1. 執行`node ./src/tests/listNotebooks.js`列出筆記本
 2. 找出欲讀取筆記本的ID後，設定至`ONENOTE_NOTEBOOK_ID`環境變數
 3. 執行`node ./src/tests/fetchNotebook.js [--min N]`讀取筆記本內容，並將對應的章節內容儲存至`./notebook_data/`中 (N 為間隔分鐘，0 表示僅執行一次，預設 5 分鐘)
-4. 執行`npm run serv`啟動簡易瀏覽伺服器，於瀏覽器開啟 `http://localhost:3000/test` 查看筆記內容
+4. 執行`npm run serv`啟動簡易瀏覽伺服器，於瀏覽器開啟 `http://localhost:3000` 查看筆記內容
 
 ## 資料格式的參考
 

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ app.set('views', path.join(__dirname, 'views'));
 
 app.use('/assets', express.static(path.join(__dirname, 'assets')));
 
-app.get('/test', (req, res) => {
+app.get('/', (req, res) => {
   const notebookId = NOTEBOOK_ID || req.query.notebookId;
   if (!notebookId) {
     return res.status(400).send('ONENOTE_NOTEBOOK_ID not set');


### PR DESCRIPTION
## Summary
- expose the test viewer at `/`
- update usage instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684b0242ee6483338e551a4250bd559a